### PR TITLE
better browserify + easier install

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "coffeeify": "^0.7.0"
+    "coffeeify": "^0.7.0",
+    "webworkify": "^1.0.0"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -6,17 +6,26 @@
   "main": "index.js",
   "repository": "https://github.com/jnordberg/gif.js.git",
   "devDependencies": {
+    "browserify": "^6.3.2",
     "commonjs-everywhere": "~0.9.4"
   },
   "scripts": {
     "prepublish": "./bin/build"
   },
-  "browser": "./dist/gif.js",
+  "browser": "./src/gif.coffee",
   "keywords": [
     "gif",
     "animation",
     "encoder"
   ],
   "license": "MIT",
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "dependencies": {
+    "coffeeify": "^0.7.0"
+  },
+  "browserify": {
+    "transform": [
+      "coffeeify"
+    ]
+  }
 }

--- a/src/GIFEncoder.js
+++ b/src/GIFEncoder.js
@@ -144,6 +144,7 @@ GIFEncoder.prototype.setTransparent = function(color) {
 GIFEncoder.prototype.addFrame = function(imageData) {
   this.image = imageData;
 
+  this.globalPalette = this.globalPalette || false;
   this.colorTab = this.globalPalette.slice ? this.globalPalette : null;
 
   this.getImagePixels(); // convert to correct format if necessary

--- a/src/gif.coffee
+++ b/src/gif.coffee
@@ -1,6 +1,8 @@
 {EventEmitter} = require 'events'
 browser = require './browser.coffee'
 
+WebWork = require 'webworkify'
+
 class GIF extends EventEmitter
 
   defaults =
@@ -101,8 +103,8 @@ class GIF extends EventEmitter
     numWorkers = Math.min(@options.workers, @frames.length)
     [@freeWorkers.length...numWorkers].forEach (i) =>
       console.log "spawning worker #{ i }"
-      worker = new Worker @options.workerScript
-      worker.onmessage = (event) =>
+      worker = WebWork(require('./gif.worker.coffee'))
+      worker.addEventListener 'message', (event) =>
         @activeWorkers.splice @activeWorkers.indexOf(worker), 1
         @freeWorkers.push worker
         @frameFinished event.data

--- a/src/gif.worker.coffee
+++ b/src/gif.worker.coffee
@@ -1,33 +1,34 @@
 GIFEncoder = require './GIFEncoder.js'
 
-renderFrame = (frame) ->
-  encoder = new GIFEncoder frame.width, frame.height
+module.exports = (self) ->
+  renderFrame = (frame) ->
+    encoder = new GIFEncoder frame.width, frame.height
 
-  if frame.index is 0
-    encoder.writeHeader()
-  else
-    encoder.firstFrame = false
+    if frame.index is 0
+      encoder.writeHeader()
+    else
+      encoder.firstFrame = false
 
-  encoder.setTransparent frame.transparent
-  encoder.setRepeat frame.repeat
-  encoder.setDelay frame.delay
-  encoder.setQuality frame.quality
-  encoder.setDither frame.dither
-  encoder.setGlobalPalette frame.globalPalette
-  encoder.addFrame frame.data
-  encoder.finish() if frame.last
-  if frame.globalPalette == true
-    frame.globalPalette = encoder.getGlobalPalette()
+    encoder.setTransparent frame.transparent
+    encoder.setRepeat frame.repeat
+    encoder.setDelay frame.delay
+    encoder.setQuality frame.quality
+    encoder.setDither frame.dither
+    encoder.setGlobalPalette frame.globalPalette
+    encoder.addFrame frame.data
+    encoder.finish() if frame.last
+    if frame.globalPalette == true
+      frame.globalPalette = encoder.getGlobalPalette()
 
-  stream = encoder.stream()
-  frame.data = stream.pages
-  frame.cursor = stream.cursor
-  frame.pageSize = stream.constructor.pageSize
+    stream = encoder.stream()
+    frame.data = stream.pages
+    frame.cursor = stream.cursor
+    frame.pageSize = stream.constructor.pageSize
 
-  if frame.canTransfer
-    transfer = (page.buffer for page in frame.data)
-    self.postMessage frame, transfer
-  else
-    self.postMessage frame
+    if frame.canTransfer
+      transfer = (page.buffer for page in frame.data)
+      self.postMessage frame, transfer
+    else
+      self.postMessage frame
 
-self.onmessage = (event) -> renderFrame event.data
+  self.onmessage = (event) -> renderFrame event.data


### PR DESCRIPTION
These changes let browserify directly bundle from source 1) using coffeeify to transform cs to js on the fly and 2) using webworkify to inline the worker js

This isn't quite ready to merge yet, (I think this will break the build/dist step) -- but wanted to get thoughts.

If the build step is fixed, this should make installation easier for script tag users (they'll only have to put one script on the page) as well as making this easily browserifyable for npm users.
