### PR TITLE
Corrects rendering of png's with colors having alpha values

### DIFF
--- a/src/gif.coffee
+++ b/src/gif.coffee
@@ -170,7 +170,7 @@ class GIF extends EventEmitter
       @_canvas.height = @options.height
 
     ctx = @_canvas.getContext '2d'
-    ctx.setFill = @options.background
+    ctx.fillStyle = @options.background
     ctx.fillRect 0, 0, @options.width, @options.height
     ctx.drawImage image, 0, 0
 


### PR DESCRIPTION
When a gif is rendered with png images having some alpha values, these colors will get mixed with the black background giving unusual output. As it is shown in #45, the gif won't render perfectly.

The solution to this would be to use a {copy: true} option on png images with a background color of white. for the gif. But this won't work as well because in the getImageData function setFill property of canvas is used which doesn't set the desired fill color instead fillStyle property should be used.
