### PR TITLE
adds support for frame disposal setting in gif89a spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ You can add `-serpentine` to use serpentine scanning, e.g. `Stucki-serpentine`.
 | -------------|-----------------|----------------------------------------------------|
 | delay        | `500`           | frame delay                                        |
 | copy         | `false`         | copy the pixel data                                |
+| dispose      | `-1`            | frame disposal code. See [GIF89a Spec][gif89aspec] |
 
+[gif89aspec]: https://www.w3.org/Graphics/GIF/spec-gif89a.txt
 
 ## Acknowledgements
 

--- a/src/gif.coffee
+++ b/src/gif.coffee
@@ -18,6 +18,7 @@ class GIF extends EventEmitter
   frameDefaults =
     delay: 500 # ms
     copy: false
+    dispose: -1
 
   constructor: (options) ->
     @running = false
@@ -181,6 +182,7 @@ class GIF extends EventEmitter
       index: index
       last: index is (@frames.length - 1)
       delay: frame.delay
+      dispose: frame.dispose
       transparent: frame.transparent
       width: @options.width
       height: @options.height

--- a/src/gif.worker.coffee
+++ b/src/gif.worker.coffee
@@ -9,6 +9,7 @@ renderFrame = (frame) ->
     encoder.firstFrame = false
 
   encoder.setTransparent frame.transparent
+  encoder.setDispose frame.dispose
   encoder.setRepeat frame.repeat
   encoder.setDelay frame.delay
   encoder.setQuality frame.quality


### PR DESCRIPTION
Frame disposal code spec is given in https://www.w3.org/Graphics/GIF/spec-gif89a.txt.
This adds support for setting `dispose` to `addFrame`.   I modified the source code but did not re-compile it, because I don't know how to do that yet. 