### PR TITLE
Remove extra padding at the end of gif

### DIFF
--- a/src/gif.coffee
+++ b/src/gif.coffee
@@ -131,16 +131,17 @@ class GIF extends EventEmitter
     len = 0
     for frame in @imageParts
       len += (frame.data.length - 1) * frame.pageSize + frame.cursor
-    len += frame.pageSize - frame.cursor
+
     @log "rendering finished - filesize #{ Math.round(len / 1000) }kb"
     data = new Uint8Array len
     offset = 0
     for frame in @imageParts
       for page, i in frame.data
-        data.set page, offset
         if i is frame.data.length - 1
+          data.set page.slice(0, frame.cursor), offset
           offset += frame.cursor
         else
+          data.set page, offset
           offset += frame.pageSize
 
     image = new Blob [data],


### PR DESCRIPTION
gif.js was always allocating a full page at the end of the Uint8Array, which results in extra (empty) space at the end of the resulting gif. It seems to work fine for browsers and most things that display gifs, but causes ffmpeg to error when trying to use a gif as the input.

This change allocates only the space needed for all frames, and slice()s out the final page to the cursor.