### PR TITLE
Simple validation for render method

### DIFF
--- a/src/gif.coffee
+++ b/src/gif.coffee
@@ -149,6 +149,7 @@ class GIF extends EventEmitter
       type: 'image/gif'
 
     @emit 'finished', image, data
+    @running = false
 
   renderNextFrame: ->
     throw new Error 'No free workers' if @freeWorkers.length is 0

--- a/src/gif.coffee
+++ b/src/gif.coffee
@@ -69,6 +69,8 @@ class GIF extends EventEmitter
     @frames.push frame
 
   render: ->
+    throw new Error 'Frames must be added prior to rendering' if @frames.length == 0
+
     throw new Error 'Already running' if @running
 
     if not @options.width? or not @options.height?


### PR DESCRIPTION
Just added a validation check for the render method in case user attempt to render without any frames. Allows the user to call it again without having to reconstruct the class. 

Also set the `@running` variable to `false` after 'finished' is emitted in the `finishRendering` method for similar reason as above.

