### PR TITLE
fix: addframe option delay equals to 0 not work

### DIFF
--- a/src/gif.coffee
+++ b/src/gif.coffee
@@ -45,7 +45,10 @@ class GIF extends EventEmitter
     frame = {}
     frame.transparent = @options.transparent
     for key of frameDefaults
-      frame[key] = options[key] or frameDefaults[key]
+      if options[key] == 0
+        frame[key] = options[key]
+      else
+        frame[key] = options[key] or frameDefaults[key]
 
     # use the images width and height for options unless already set
     @setOption 'width', image.width unless @options.width?


### PR DESCRIPTION
there is an error that if delay equals to 0, the addFrame would use Default value of 500, which is not match the point.